### PR TITLE
add blast as fallback rpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dzapio/dzap-sdk",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "description": "This project is a thin React wrapper around DZap, to easily call functionalities/contract integration.",
   "main": "dist/index.js",
   "module": "dist/index.m.js",
@@ -57,7 +57,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@walletconnect/ethereum-provider": "^2.13.0",
     "axios": "^1.2.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.1.0",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,5 @@
 import { AppEnv } from 'src/enums';
-import { Abi, Chain } from 'viem';
-import { mainnet, arbitrum, bsc, optimism, polygon, zkSync } from 'viem/chains';
+import { Abi } from 'viem';
 const { REACT_APP_ENV, REACT_APP_BASE_API_URL } = process.env;
 
 let baseUrl = REACT_APP_BASE_API_URL || 'https://api.dzap.io/';
@@ -32,13 +31,4 @@ export const batchSwapIntegrators: {
   dZap: {
     contract: '0x12480616436DD6D555f88B8d94bB5156E28825B1',
   },
-};
-
-export const Chains: { [key: number]: Chain } = {
-  1: mainnet,
-  10: optimism,
-  56: bsc,
-  137: polygon,
-  42161: arbitrum,
-  324: zkSync,
 };

--- a/src/contractHandler/index.ts
+++ b/src/contractHandler/index.ts
@@ -1,11 +1,10 @@
+import { Signer } from 'ethers';
 import { fetchBridgeParams, fetchSwapParams } from 'src/api';
+import { Services } from 'src/constants';
 import { WalletClient } from 'viem';
 import { BridgeParamsRequest, BridgeParamsResponse, HexString, SwapParamsRequest } from '../types';
 import { getDZapAbi, isTypeSigner, wagmiChainsById } from '../utils';
 import { handleTransactionError } from '../utils/errors';
-import { Signer } from 'ethers';
-import { Services } from 'src/constants';
-
 class ContractHandler {
   private static instance: ContractHandler;
   // private constructor() {}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,7 +29,7 @@ export type Chain = {
   multicallAddress: string;
   blockExplorerUrl: string;
   nativeToken: NativeTokenInfo;
-  rpcProvider: ApiRpcResponse;
+  rpcProviders: ApiRpcResponse[];
   pricingAvailable: boolean;
   balanceAvailable: boolean;
   supportedAs: {
@@ -41,7 +41,7 @@ export type Chain = {
 export type ApiRpcResponse = {
   url: string;
   keyRequired: boolean;
-  keyType?: 'ALCHEMY_KEY';
+  keyType?: 'ALCHEMY_KEY' | 'BLASTAPI_KEY';
 };
 
 // Swap

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,10 +1,10 @@
 import { Signer } from 'ethers';
-import { createPublicClient, getAddress, http, ParseEventLogsReturnType, stringToHex, Abi, parseEventLogs, TransactionReceipt } from 'viem';
-import * as allWagmiChains from 'viem/chains';
-import { Chains, batchSwapIntegrators, isStaging } from '../config';
-import { HexString, AvailableDZapServices, OtherAvailableAbis } from '../types';
-import * as ABI from '../artifacts';
 import { DZapAbis, OtherAbis, Services } from 'src/constants';
+import { Abi, ParseEventLogsReturnType, TransactionReceipt, getAddress, parseEventLogs, stringToHex } from 'viem';
+import * as allWagmiChains from 'viem/chains';
+import * as ABI from '../artifacts';
+import { batchSwapIntegrators, isStaging } from '../config';
+import { AvailableDZapServices, HexString, OtherAvailableAbis } from '../types';
 
 export const wagmiChainsById: Record<number, allWagmiChains.Chain> = Object.values(allWagmiChains).reduce((acc, chainData) => {
   return chainData.id
@@ -16,13 +16,6 @@ export const wagmiChainsById: Record<number, allWagmiChains.Chain> = Object.valu
 }, {});
 
 export const getChecksumAddress = (address: string): HexString => getAddress(address);
-
-export const initializeReadOnlyProvider = ({ chainId, rpcProvider }: { rpcProvider: string; chainId: number }) => {
-  return createPublicClient({
-    chain: Chains[chainId],
-    transport: http(rpcProvider),
-  });
-};
 
 export const getIntegratorInfo = (integrator?: string) => batchSwapIntegrators[integrator] || batchSwapIntegrators.dZap;
 


### PR DESCRIPTION
- Add `BLASTAPI_KEY` for fallback RPC.
- Remove unused package `@walletconnect/ethereum-provider`
- Updated to sdk version `2.0.30`